### PR TITLE
缺少依赖库，编译不通过

### DIFF
--- a/fdkaac/enc.go
+++ b/fdkaac/enc.go
@@ -24,7 +24,7 @@ package fdkaac
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/../fdk-aac-lib/objs/include/fdk-aac
-#cgo LDFLAGS: ${SRCDIR}/../fdk-aac-lib/objs/lib/libfdk-aac.a
+#cgo LDFLAGS: ${SRCDIR}/../fdk-aac-lib/objs/lib/libfdk-aac.a -lm
 #include "aacenc_lib.h"
 
 typedef struct {


### PR DESCRIPTION
//系统版本
Linux version 3.10.0-957.21.3.el7.x86_64  (gcc version 4.8.5 20150623 (Red Hat 4.8.5-36) (GCC) ) #1 SMP Tue Jun 18 16:35:19 UTC 2019

go build编译报错：
# github.com/winlinvip/go-fdkaac/fdkaac
../github.com/winlinvip/go-fdkaac/fdkaac/../fdk-aac-lib/objs/lib/libfdk-aac.a(genericStds.o)：在函数‘FDKsqrt’中：
../github.com/winlinvip/go-fdkaac/fdk-aac-lib/libSYS/src/genericStds.cpp:358：对‘sqrt’未定义的引用
../github.com/winlinvip/go-fdkaac/fdkaac/../fdk-aac-lib/objs/lib/libfdk-aac.a(genericStds.o)：在函数‘FDKpow’中：
../github.com/winlinvip/go-fdkaac/fdk-aac-lib/libSYS/src/genericStds.cpp:357：对‘pow’未定义的引用
../github.com/winlinvip/go-fdkaac/fdkaac/../fdk-aac-lib/objs/lib/libfdk-aac.a(genericStds.o)：在函数‘FDKatan’中：
../github.com/winlinvip/go-fdkaac/fdk-aac-lib/libSYS/src/genericStds.cpp:359：对‘atan’未定义的引用
../github.com/winlinvip/go-fdkaac/fdkaac/../fdk-aac-lib/objs/lib/libfdk-aac.a(genericStds.o)：在函数‘FDKlog’中：
../github.com/winlinvip/go-fdkaac/fdk-aac-lib/libSYS/src/genericStds.cpp:360：对‘log’未定义的引用
../github.com/winlinvip/go-fdkaac/fdkaac/../fdk-aac-lib/objs/lib/libfdk-aac.a(genericStds.o)：在函数‘FDKsin’中：
(此处省略一堆重复错误)
collect2: 错误：ld 返回 1